### PR TITLE
Explicitly mark slice range as increasing in Magma.Utils.extract_link_text/1

### DIFF
--- a/lib/magma/utils.ex
+++ b/lib/magma/utils.ex
@@ -68,7 +68,7 @@ defmodule Magma.Utils do
 
   """
   def extract_link_text("[[" <> string) do
-    String.slice(string, 0..-3)
+    String.slice(string, 0..-3//1)
   end
 
   def extract_link_text(_), do: nil


### PR DESCRIPTION
I know this looks like a nit, but I'm trying out this very interesting project and troubleshooting why the buttons in Obsidian aren't working in my environment. I'm getting a bit of backtrace for this, so I thought I'd fix it to eliminate it from the output.

![screenshot2023-11-09-15 56 42](https://github.com/marcelotto/magma/assets/1639/c9e76874-4c29-4439-8a5e-ff799b450305)


Per the [elixir docs](https://hexdocs.pm/elixir/String.html#slice/2):

> For ranges where start > stop, you need to explicitly mark them as increasing
